### PR TITLE
Updates to project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,44 @@
 # TicTacToe
-A TicTacToe application built in Elixir, which allows a user to play the game from 
-the Command Line or a Web Server.
-
-## Getting Started
-Refer to [Installing Elixir](https://elixir-lang.org/install.html) for guidance on 
-installing Elixir on your local machine  
-Useful Resource:- [Elixir Documentation](https://elixir-lang.org/docs.html)
+A TicTacToe application built using Elixir, that allows a user to play the game from 
+the Command Line. The game can wither be played Human vs Human or Human vs Computer. 
+Intended future behaviour is to allow a user to play the game from a Web Server. 
 
 ## Features
 - [x] A human vs human game which runs on the Command Line  
 - [x] A human vs computer game which runs on the Command Line  
-- [] An HTTP client so that the game to be played on a locally hosted web server  
+- [] An HTTP client so that the game to be played on a locally hosted web server 
+
+## Getting Started
+Refer to [Installing Elixir](https://elixir-lang.org/install.html) for guidance on 
+installing Elixir on your local machine  
+Useful Resource: [Elixir Documentation](https://elixir-lang.org/docs.html)
 
 ## Running the Application
-Once cloned, run the command `mix escript.build` to build the executable  
-Then call `./tictactoe --version=hh` to load a Human vs Human game  
-Or, call `./tictactoe --version=hc` to load a Human vs Computer game  
+Run the command `mix escript.build` to build the executable. 
+
+### Compiling the Application
+Compile the application with the command `mix compile`. 
+
+### CLI
+Call the following depending on which type of game you'd like to load: 
+- Human vs Human `./tictactoe --version=hh`
+- Human vs Computer `./tictactoe --version=hc` 
 
 ## Testing
 Use command `mix test` to run the test files.
 
+
+You should see output similar to the following in your terminal: 
+```
+.........................
+Finished in 0.5 seconds (0.05s async, 0.5s sync)
+29 tests, 0 failures
+```
+
 ----------------
+
+## Documentation
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
+and published on [HexDocs](https://hexdocs.pm). 
+Once published, the docs can
 be found at [https://hexdocs.pm/tictactoe](https://hexdocs.pm/tictactoe).

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,5 +1,5 @@
 # This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+# and its dependencies with the aid of the Config module.
+import Config
 
 import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,5 +1,5 @@
 # This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+# and its dependencies with the aid of the Config module.
+import Config
 
 config :tictactoe, port: 4001

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,5 +1,5 @@
 # This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+# and its dependencies with the aid of the Config module.
+import Config
 
 config :tictactoe, port: 4000

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,5 +1,5 @@
 # This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+# and its dependencies with the aid of the Config module.
+import Config
 
 config :tictactoe, port: 80

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule TicTacToe.MixProject do
     [
       app: :tictactoe,
       version: "0.1.0",
-      elixir: "~> 1.8",
+      elixir: "~> 1.16",
       start_permanent: Mix.env() == :prod,
       escript: escript(),
       deps: deps()

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,11 @@
+%{
+  "cowboy": {:hex, :cowboy, "2.12.0", "f276d521a1ff88b2b9b4c54d0e753da6c66dd7be6c9fca3d9418b561828a3731", [:make, :rebar3], [{:cowlib, "2.13.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "1.8.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm", "8a7abe6d183372ceb21caa2709bec928ab2b72e18a3911aa1771639bef82651e"},
+  "cowlib": {:hex, :cowlib, "2.13.0", "db8f7505d8332d98ef50a3ef34b34c1afddec7506e4ee4dd4a3a266285d282ca", [:make, :rebar3], [], "hexpm", "e1e1284dc3fc030a64b1ad0d8382ae7e99da46c3246b815318a4b848873800a4"},
+  "mime": {:hex, :mime, "2.0.5", "dc34c8efd439abe6ae0343edbb8556f4d63f178594894720607772a041b04b02", [:mix], [], "hexpm", "da0d64a365c45bc9935cc5c8a7fc5e49a0e0f9932a761c55d6c52b142780a05c"},
+  "plug": {:hex, :plug, "1.15.3", "712976f504418f6dff0a3e554c40d705a9bcf89a7ccef92fc6a5ef8f16a30a97", [:mix], [{:mime, "~> 1.0 or ~> 2.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.1.1 or ~> 1.2 or ~> 2.0", [hex: :plug_crypto, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4.3 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "cc4365a3c010a56af402e0809208873d113e9c38c401cabd88027ef4f5c01fd2"},
+  "plug_cowboy": {:hex, :plug_cowboy, "2.1.3", "38999a3e85e39f0e6bdfdf820761abac61edde1632cfebbacc445cdcb6ae1333", [:mix], [{:cowboy, "~> 2.5", [hex: :cowboy, repo: "hexpm", optional: false]}, {:plug, "~> 1.7", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm", "056f41f814dbb38ea44613e0f613b3b2b2f2c6afce64126e252837669eba84db"},
+  "plug_crypto": {:hex, :plug_crypto, "2.0.0", "77515cc10af06645abbfb5e6ad7a3e9714f805ae118fa1a70205f80d2d70fe73", [:mix], [], "hexpm", "53695bae57cc4e54566d993eb01074e4d894b65a3766f1c43e2c61a1b0f45ea9"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm", "fec8660eb7733ee4117b85f55799fd3833eb769a6df71ccf8903e8dc5447cfce"},
+  "ranch": {:hex, :ranch, "1.8.0", "8c7a100a139fd57f17327b6413e4167ac559fbc04ca7448e9be9057311597a1d", [:make, :rebar3], [], "hexpm", "49fbcfd3682fab1f5d109351b61257676da1a2fdbe295904176d5e521a2ddfe5"},
+  "telemetry": {:hex, :telemetry, "1.2.1", "68fdfe8d8f05a8428483a97d7aab2f268aaff24b49e0f599faa091f1d4e7f61c", [:rebar3], [], "hexpm", "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5"},
+}


### PR DESCRIPTION
Apply the following updates: 

- update Elixir version from `1.8` to `1.16`
- remove deprecated `use Mix.Config` and replace with `import Config`
- update README details
- add auto-generated `mix.lock` file
